### PR TITLE
Ldap based test to use a test ldap server that is setup, parameterising credentials

### DIFF
--- a/specs/TestUserCredentialsWithLdap.spec
+++ b/specs/TestUserCredentialsWithLdap.spec
@@ -24,24 +24,18 @@ TestUserCredentialsWithLdap
 tags: 6441, ldap
 
 user should get logged in if valid ldap credentials are provided
-* Login with username "cruise_builder" and password "BXrQ51uhU"
-* User should get logged in as "Cruise Builder"
+* Login with username "user1" and password "pass_user1"
+* User should get logged in as "User_user1 LastName_user1"
 
 
 user should see error message when incorrect username is provided
-* Login with username "cruise_builder1" and password "BXrQ51uhU"
-* Assert login error "User cruise_builder1 not found in directory. Help Topic: Authentication"
-
-
-user should see error message when incorrect password is provided
-* Login with username "cruise_builder" and password "1BXrQ51uhU"
+* Login with username "does_not_exist" and password "password"
 * Assert login error "Bad credentials Help Topic: Authentication"
 
 
-
-
-
-
+user should see error message when incorrect password is provided
+* Login with username "user1" and password "incorrect_password"
+* Assert login error "Bad credentials Help Topic: Authentication"
 
 
 Teardown of contexts

--- a/specs/TfsMaterial.spec
+++ b/specs/TfsMaterial.spec
@@ -91,7 +91,7 @@ tags: tfs, 6194
 
 * Looking at material of type "Tfs" named "tfs_mat"
 * Verify material has changed - Already On Build Cause Section
-* Verify modification "0" is checked in by "CORPORATE\\cruise_builder" with comment "interesting comment by luser"
+* Verify tfs modification "0" is checked in by authorized user with comment "interesting comment by luser"
 
 * Click on pipeline "basic-tfs-pipeline" for editing
 

--- a/specs/TfsMaterialSchedulingAndMaterialModification.spec
+++ b/specs/TfsMaterialSchedulingAndMaterialModification.spec
@@ -56,7 +56,7 @@ verify first instance built with older material
 
 * Looking at material of type "Tfs" named "tfs_mat"
 * Verify material has changed - Already On Build Cause Section
-* Verify modification "0" is checked in by "CORPORATE\\cruise_builder" with comment "interesting comment by luser"
+* Verify tfs modification "0" is checked in by authorized user with comment "interesting comment by luser"
 
 verify second instance built with newer material
 * Navigate to materials for "tfs-pipeline-with-multiple-stages" "2" "stage1" "1"

--- a/specs/TfsMaterialViewerAndEditor.spec
+++ b/specs/TfsMaterialViewerAndEditor.spec
@@ -29,9 +29,9 @@ tags: Clicky Admin, #5775, 6191, tfs
 * Open parameters page
 
 * Enter tfs url as parameter "1" with name "valid_tfs_url" and value "integration_tests"
-* Enter parameter "2" name "username" and value "cruise_builder"
+* Enter parameter "2" name "username" and derive value from environment variable "TFS_SERVER_USERNAME"
 * Enter parameter "3" name "valid_project_path" and value "$/for_tests"
-* Enter parameter "4" name "domain" and value "corporate"
+* Enter parameter "4" name "domain" and derive value from environment variable "TFS_SERVER_DOMAIN"
 * Enter parameter "5" name "destination_dir" and value "tfs_destination"
 * Enter tfs url as parameter "6" with name "invalid_tfs_url" and value "incorrect_url"
 * Enter parameter "7" name "invalid_username" and value "invalidUser"
@@ -61,12 +61,12 @@ tags: Clicky Admin, #5775, 6191, tfs
 * Click check connection
 * Verify message "Access denied connecting to TFS server"
 * Enter username "#{username}" - Already on Tfs Material Creation Popup
-* Enter password "BXrQ51uhU" - Already on Tfs Material Creation Popup
+* Enter valid password - Already on Tfs Material Creation Popup
 * Enter project path as "$/invalid_project_path"
-* Enter domain "corporate"
+* Enter valid domain
 * Click check connection
 * Verify message "project path might be invalid"
-* Enter username "cruise_builder" - Already on Tfs Material Creation Popup
+* Enter valid username - Already on Tfs Material Creation Popup
 * Enter project path as "#{invalid_project_path}"
 * Click check connection
 * Verify message "project path might be invalid"

--- a/src/test/java/com/thoughtworks/cruise/context/configuration/ValidLdapConfiguration.java
+++ b/src/test/java/com/thoughtworks/cruise/context/configuration/ValidLdapConfiguration.java
@@ -21,12 +21,13 @@ package com.thoughtworks.cruise.context.configuration;
 import com.thoughtworks.cruise.context.Configuration;
 import com.thoughtworks.cruise.state.RepositoryState;
 import com.thoughtworks.cruise.state.ScenarioState;
+import com.thoughtworks.cruise.util.SystemUtil;
 import com.thoughtworks.cruise.utils.ScenarioHelper;
+import com.thoughtworks.cruise.utils.configfile.CruiseConfigDom;
 import net.sf.sahi.client.Browser;
+import org.apache.commons.lang3.StringUtils;
 
 public class ValidLdapConfiguration extends AbstractConfiguration{
-
-
 	public ValidLdapConfiguration(Configuration config, ScenarioState state, RepositoryState repositoryState, ScenarioHelper scenarioHelper, Browser browser) throws Exception {
 		super("/config/valid-ldap-server-cruise-config.xml",config,state,repositoryState, scenarioHelper, browser);
 	}
@@ -35,6 +36,13 @@ public class ValidLdapConfiguration extends AbstractConfiguration{
 	public void setUp() throws Exception {
 		super.setUp();
 	}
+
+	protected void postProcess(CruiseConfigDom dom) throws Exception {
+		String ldapServerIp = System.getenv("LDAP_SERVER_IP");
+		if (StringUtils.isBlank(ldapServerIp)) throw new RuntimeException(String.format("%s is not set", ldapServerIp));
+		dom.getLdap().attribute("uri").setValue("ldap://" + ldapServerIp);
+	}
+
 
 	@com.thoughtworks.gauge.Step("Valid ldap configuration - teardown")
 	public void tearDown() throws Exception {

--- a/src/test/java/com/thoughtworks/cruise/editpipelinewizard/AlreadyOnNewPipelineWizard.java
+++ b/src/test/java/com/thoughtworks/cruise/editpipelinewizard/AlreadyOnNewPipelineWizard.java
@@ -64,7 +64,7 @@ public class AlreadyOnNewPipelineWizard extends AlreadyOnEditPipelineWizardPage 
     
     @com.thoughtworks.gauge.Step("Set tfs collection <collection>")
 	public void setTfsCollection(String collection) throws Exception {
-    	FormField formField = new FormField(scenarioState.expand(String.format("pipeline_group[pipeline][materials][TfsMaterial][url](text_field): %s%s", new TfsServer().getUrl(), collection)));    	
+    	FormField formField = new FormField(scenarioState.expand(String.format("pipeline_group[pipeline][materials][TfsMaterial][url](text_field): %s%s", TfsServer.getUrl(), collection)));
         formField.setValue(browser);
     }
 

--- a/src/test/java/com/thoughtworks/cruise/editpipelinewizard/AlreadyOnParametersPage.java
+++ b/src/test/java/com/thoughtworks/cruise/editpipelinewizard/AlreadyOnParametersPage.java
@@ -81,7 +81,7 @@ public class AlreadyOnParametersPage extends AlreadyOnEditPipelineWizardPage {
 
 	@com.thoughtworks.gauge.Step("Enter tfs url as parameter <parameterLocation> with name <name> and value <collection>")
 	public void enterTfsUrlAsParameterWithNameAndValue(Integer parameterLocation, String name, String collection) throws Exception {
-		enterParameterNameAndValue(parameterLocation, name, new TfsServer().getUrl() + collection);
+		enterParameterNameAndValue(parameterLocation, name, TfsServer.getUrl() + collection);
 	}
 
     @com.thoughtworks.gauge.Step("Enter parameter <parameterLocation> name <parameterName> and value <parameterValue>")
@@ -92,6 +92,11 @@ public class AlreadyOnParametersPage extends AlreadyOnEditPipelineWizardPage {
         getParamTextBox(getParameterNameFieldId(parameterLocation)).setValue(parameterName);
         getParamTextBox(getParameterValueFieldId(parameterLocation)).setValue(parameterValue);
     }
+
+    @com.thoughtworks.gauge.Step("Enter parameter <parameterLocation> name <parameterName> and derive value from environment variable <environmentVariable>")
+	public void enterParameterNameAndDeriveValueFromEnvVar(Integer parameterLocation, String parameterName, String environmentVariable) throws Exception {
+		enterParameterNameAndValue(parameterLocation, parameterName, System.getenv(environmentVariable));
+	}
 
 	@com.thoughtworks.gauge.Step("Enter material url for parameter <parameterLocation> name <parameterName> and material name <materialName> associated with pipeline <parentPipelineName>")
 	public void enterMaterialUrlForParameterNameAndMaterialNameAssociatedWithPipeline(

--- a/src/test/java/com/thoughtworks/cruise/editpipelinewizard/AlreadyOnTfsMaterialCreationPopup.java
+++ b/src/test/java/com/thoughtworks/cruise/editpipelinewizard/AlreadyOnTfsMaterialCreationPopup.java
@@ -43,17 +43,27 @@ public class AlreadyOnTfsMaterialCreationPopup extends AlreadyOnEditMaterialPopu
 	
 	@com.thoughtworks.gauge.Step("Enter url <collection> - Already on tfs material creation popup")
 	public void enterUrl(String collection) throws Exception {
-        super.enterUrl(new TfsServer().getUrl() + collection);
+        super.enterUrl(TfsServer.getUrl() + collection);
     }
 
 	@com.thoughtworks.gauge.Step("Enter username <userName> - Already on Tfs Material Creation Popup")
 	public void enterUsername(String userName) throws Exception {
 		elementUsername().setValue(userName);
 	}
-	
+
+	@com.thoughtworks.gauge.Step("Enter valid username - Already on Tfs Material Creation Popup")
+	public void enterValidUsername() throws Exception {
+		enterUsername(TfsServer.getUsername());
+	}
+
 	@com.thoughtworks.gauge.Step("Enter domain <domain>")
 	public void enterDomain(String domain) throws Exception {
 		elementDomain().setValue(domain);
+	}
+
+	@com.thoughtworks.gauge.Step("Enter valid domain")
+	public void enterValidDomain() throws Exception {
+		enterDomain(TfsServer.getDomain());
 	}
 
 	private ElementStub elementUsername() {
@@ -63,6 +73,11 @@ public class AlreadyOnTfsMaterialCreationPopup extends AlreadyOnEditMaterialPopu
 	@com.thoughtworks.gauge.Step("Enter password <password> - Already on Tfs Material Creation Popup")
 	public void enterPassword(String password) throws Exception {
 		elementPassword().setValue(password);
+	}
+
+	@com.thoughtworks.gauge.Step("Enter valid password - Already on Tfs Material Creation Popup")
+	public void enterValidPassword() throws Exception {
+		enterPassword(TfsServer.getPassword());
 	}
 
 	private ElementStub elementPassword() {

--- a/src/test/java/com/thoughtworks/cruise/materials/TfsRepository.java
+++ b/src/test/java/com/thoughtworks/cruise/materials/TfsRepository.java
@@ -43,7 +43,7 @@ public class TfsRepository extends AbstractRepository {
     }
 
     private void initializeTestWorkspace() {
-        CommandLine cmd = createCommandLine(tfCommand()).withArgs("workspace", "-new", "-noprompt", serverArg(), loginArg(), workspaceName + ";"+ new TfsServer().getUsername());
+        CommandLine cmd = createCommandLine(tfCommand()).withArgs("workspace", "-new", "-noprompt", serverArg(), loginArg(), workspaceName + ";"+ TfsServer.getUsername());
         cmd.getArguments();
         cmd.runOrBomb();
     }
@@ -64,8 +64,7 @@ public class TfsRepository extends AbstractRepository {
     }
     
     private String loginArg() {
-        TfsServer tfsServer = new TfsServer();
-        return String.format("-login:%s\\%s,%s", tfsServer.getDomain(), tfsServer.getUsername(), tfsServer.getPassword());
+        return String.format("-login:%s\\%s,%s", TfsServer.getDomain(), TfsServer.getUsername(), TfsServer.getPassword());
     }
 
     private String serverArg() {
@@ -74,21 +73,20 @@ public class TfsRepository extends AbstractRepository {
 
     @Override
     public String getUrl() {
-        return new TfsServer().getDefaultTfsCollectionUrl();
+        return TfsServer.getDefaultTfsCollectionUrl();
     }
 
     @Override
     public void setOtherAttributes(Element element) {
-        TfsServer tfsServer = new TfsServer();
         super.setOtherAttributes(element);
         if (element.attribute("username") != null) {
-            element.attribute("username").setValue(tfsServer.getUsername());
+            element.attribute("username").setValue(TfsServer.getUsername());
         }
         if (element.attribute("password") != null) {
-            element.attribute("password").setValue(tfsServer.getPassword());
+            element.attribute("password").setValue(TfsServer.getPassword());
         }
         if (element.attribute("domain") != null) {
-            element.attribute("domain").setValue(tfsServer.getDomain());
+            element.attribute("domain").setValue(TfsServer.getDomain());
         }
     }
 

--- a/src/test/java/com/thoughtworks/cruise/materials/TfsServer.java
+++ b/src/test/java/com/thoughtworks/cruise/materials/TfsServer.java
@@ -19,27 +19,27 @@ package com.thoughtworks.cruise.materials;
 import org.apache.commons.lang.StringUtils;
 
 public class TfsServer {
-    public String getUrl() {
+    public static String getUrl() {
         return getPropertyOrBomb("TFS_SERVER_URL");
     }
 
-    public String getDefaultTfsCollectionUrl() {
+    public static String getDefaultTfsCollectionUrl() {
         return getUrl() + "twist_tests";
     }
 
-    public String getPassword() {
+    public static String getPassword() {
         return getPropertyOrBomb("TFS_SERVER_PASSWORD");
     }
 
-    public String getDomain() {
+    public static String getDomain() {
         return getPropertyOrBomb("TFS_SERVER_DOMAIN");
     }
 
-    public String getUsername() {
+    public static String getUsername() {
         return getPropertyOrBomb("TFS_SERVER_USERNAME");
     }
 
-    private String getPropertyOrBomb(String propertyName) {
+    private static String getPropertyOrBomb(String propertyName) {
         String username = System.getenv(propertyName);
         if (StringUtils.isBlank(username)) throw new RuntimeException(String.format("%s is not set", propertyName));
         return username;

--- a/src/test/java/com/thoughtworks/cruise/page/AlreadyOnBuildCauseSection.java
+++ b/src/test/java/com/thoughtworks/cruise/page/AlreadyOnBuildCauseSection.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.cruise.page;
 
 import com.thoughtworks.cruise.Regex;
+import com.thoughtworks.cruise.materials.TfsServer;
 import com.thoughtworks.cruise.state.RepositoryState;
 import com.thoughtworks.cruise.state.ScenarioState;
 import net.sf.sahi.client.Browser;
@@ -96,6 +97,10 @@ public class AlreadyOnBuildCauseSection {
             username = String.format("%s on %s", split[0], format);
         }
 		assertThat(elementModification(modificationOffset, "modified_by").getText().trim(), containsString(username));
+	}
+	@com.thoughtworks.gauge.Step("Verify tfs modification <modificationOffset> is checked in by authorized user with comment <comment>")
+	public void verifyTfsModificationIsCheckedInByAuthorizedUserWithComment(Integer modificationOffset, String comment) throws Exception {
+		verifyModificationIsCheckedInByWithComment(modificationOffset, String.format("%s\\%s", TfsServer.getDomain(), TfsServer.getUsername()), comment);
 	}
 
 

--- a/src/test/java/com/thoughtworks/cruise/utils/configfile/CruiseConfigDom.java
+++ b/src/test/java/com/thoughtworks/cruise/utils/configfile/CruiseConfigDom.java
@@ -1650,7 +1650,7 @@ public class CruiseConfigDom {
 			String[] nameAndValue = nameValue.split(">");
 			String value = nameAndValue[1];
 			if("tfs".equals(materialType) && "url".equals(nameAndValue[0])){
-				value = new TfsServer().getUrl() + value;
+				value = TfsServer.getUrl() + value;
 			}
 			Attribute attrib = material.attribute(nameAndValue[0]);
 			if (attrib == null || !attrib.getText().equals(value)) {

--- a/src/test/java/config/valid-ldap-server-cruise-config.xml
+++ b/src/test/java/config/valid-ldap-server-cruise-config.xml
@@ -18,11 +18,11 @@
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="77">
   <server artifactsdir="artifacts" serverId="twist">
       <security>
-            <ldap uri="ldap://chidc04.corporate.thoughtworks.com" managerDn="cn=Active Directory Ldap User,ou=InformationSystems,ou=SharedAccounts,ou=Principal,dc=corporate,dc=thoughtworks,dc=com" managerPassword="!@dus3r!" searchFilter="(sAMAccountName={0})" >
-		      	<bases>
-      				<base value="ou=Enterprise,ou=Principal,dc=corporate,dc=thoughtworks,dc=com"/>
-      			</bases>
-      		</ldap>  
+          <ldap uri="$ldap_server" searchFilter="(uid={0})">
+              <bases>
+                  <base value="ou=People,dc=tests,dc=com" />
+              </bases>
+          </ldap>
     </security>
   </server>
 </cruise>


### PR DESCRIPTION
- Test ldap server is run on a docker container-> https://github.com/gocd/docker-slapd. 
- Removing stale credentials from code. credentials can be passed along as environment variables

Currently the VMs have centos6.5 so facing some trouble with docker install on them and hence using a separate centos6.6 machine to run the container. Once OS on all agents are upgraded, the tests could be changed to bring up their individual ldap server before the test and shut them down during teardown so all logic around it is contained in the same place.
