### PR TITLE
Add ignore tag to SmokeTest spec since it fails on ie11, this is temp…

### DIFF
--- a/specs/SmokeTest.spec
+++ b/specs/SmokeTest.spec
@@ -24,7 +24,7 @@ Setup of contexts
 SmokeTest
 ---------
 
-tags: automate, smoke, #3303
+tags: automate, smoke, #3303, ignore_on_ie
 
 
 * Setting first stage of "downstream-pipeline" to auto approval


### PR DESCRIPTION
…orary fix, need to move SmokeTest spec to webdriver
