### PR TITLE
Script the setup process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tags
 out/
 nohup.out
 sahi/userdata/
+libs

--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ Badge](https://cdn.rawgit.com/getgauge/getgauge.github.io/master/Gauge_Badge.svg
 * [Gauge](http://getgauge.io)
 
 ## Setup
-* ``` git clone``` as a sibling directory to
-  [go.cd](https://github.com/gocd/gocd)
-* ```$ cd gocd-functional-tests```
-* ```$ gauge --install-all```
-
-## Prepare
-* cd to ```gocd-plugins``` codebase, run : ```$ mvn clean install -DskipTests```
-* cd to ```gocd``` codebase, run : ```$ ./bn clean
-  cruise:prepare dist ALLOW_NON_PRODUCTION_CODE=yes```
-* cd to ```gocd-functional-tests``` and run : ```$ ./b clean setup```
-* ```./b start_server``` 
+```
+$ git clone https://github.com/gocd/gocd
+$ git clone https://github.com/gocd/go-plugins
+$ git clone https://github.com/gocd/functional-tests
+$ cd functional-tests
+$ ./b setup
+$ ./b start_server
+```
 
 ## Running tests
 
-* ```gauge specs/AdminTaskListing.spec```
+```
+$ gauge install-all
+$ gauge specs/AdminTaskListing.spec
+```
 
 ## Contributing
 

--- a/buildfile
+++ b/buildfile
@@ -100,6 +100,10 @@ task :resolve_dependencies do
   cp _cruise.compile.dependencies.collect { |t| t.to_s }, _cruise.path_to('tempo')
 end
 
+task :dependencies do
+  sh 'mvn clean install -q'
+end
+
 task :build_plugins do
   cd "../#{GO_PLUGINS_DIRNAME}" do
     sh './gradlew assemble -q'
@@ -150,7 +154,7 @@ task :clean do
   rm_rf './target'
 end
 
-task :setup => [:clean, :copy_agent, :copy_server, :copy_plugins] do
+task :setup => [:clean, :dependencies, :copy_agent, :copy_server, :copy_plugins] do
 end
 
 
@@ -159,7 +163,7 @@ task :kill_server do
     system("target\go-server-#{VERSION_NUMBER}\stop-server.bat")
   else
     system("pkill -f cruise.jar")
-    end
+  end
 end
 
 def kill_gauge

--- a/src/test/java/com/thoughtworks/cruise/util/CruiseConstants.java
+++ b/src/test/java/com/thoughtworks/cruise/util/CruiseConstants.java
@@ -64,7 +64,7 @@ public class CruiseConstants {
     public static final String APPROVAL_SUCCESS = "success";
     public static final String APPROVAL_MANUAL = "manual";
     public static final int PUBLISH_MAX_RETRIES = 3;
-    public static final String CURRENT_REVISION = System.getenv("GO_VERSION") != null ? System.getenv("GO_VERSION") : "16.1.0";
+    public static final String CURRENT_REVISION = System.getenv("GO_VERSION");
     public static final String TEST_EMAIL_SUBJECT = "Cruise Email Notification";
     public static final int DEFAULT_TIMEOUT = 60 * 1000;
     public static final String LICENSE_LIMITATION_ERROR = "License limitation error";
@@ -77,4 +77,9 @@ public class CruiseConstants {
     public static final String apiV1 = "application/vnd.go.cd.v1+json";
     public static final String apiV2 = "application/vnd.go.cd.v2+json";
 
+    static {
+        if(System.getenv("GO_VERSION") == null){
+            throw new AssertionError("Set the GO_VERSION environment variable");
+        }
+    }
 }


### PR DESCRIPTION
Wrote a bunch of tasks to build and setup go-server with plugins to make running functional tests easier.
Use the new gradle build location to generate the sever jars.

This change should be merged in only after 16.7 release and after migrating go-plugins build to gradle.
