### PR TITLE
Going back to-Making the case of username in password file consistent across specs

### DIFF
--- a/specs/ComparePipelinesWithDifferentPermissions.spec
+++ b/specs/ComparePipelinesWithDifferentPermissions.spec
@@ -97,7 +97,7 @@ tags: 4643, automate, compare_pipeline, dependency_walk, 4687, 6786
 * Click on upstream pipeline revision "${runtime_name:first-pipeline}/1/defaultStage/1"
 * Verify that unauthorized access message is shown
 
-* Logout and login as "group1view"
+* Logout and login as "group1View"
 
 * Verify pipeline "first-pipeline" is visible
 * Looking at pipeline "down-pipeline"

--- a/specs/PipelineDashboardAndActivitySecurityWithMultiplePermissions.spec
+++ b/specs/PipelineDashboardAndActivitySecurityWithMultiplePermissions.spec
@@ -34,7 +34,7 @@ Verify that user 'group1view' gets union of the different permissions specified 
 
 * Logout - On Any Page
 
-* Login as "group1view"
+* Login as "group1View"
 
 
 Pipeline Visibility

--- a/specs/PipelineDashboardAndPipelineActivitySecurity.spec
+++ b/specs/PipelineDashboardAndPipelineActivitySecurity.spec
@@ -106,7 +106,7 @@ Pipeline Visibility
 
 * Logout - On Any Page
 
-* Login as "group1view"
+* Login as "group1View"
 
 
 Pipeline Visibility

--- a/specs/PipelineDashboardAndPipelineActivitySecurityAtStageLevel.spec
+++ b/specs/PipelineDashboardAndPipelineActivitySecurityAtStageLevel.spec
@@ -98,7 +98,7 @@ Pipeline Visibility
 
 * Logout - On Any Page
 
-* Login as "group1view"
+* Login as "group1View"
 
 Pipeline Visibility
 * PipelineVisibility 

--- a/specs/PropertiesSecurityWithStageOverriding.spec
+++ b/specs/PropertiesSecurityWithStageOverriding.spec
@@ -72,7 +72,7 @@ commented line verification to be put back after #6827 or #6809 is fixed
 * verify property "prop_name_api_6" with value "prop_value_api_6" for pipeline "P6" stage "secondStage" label "1" counter "1" job "secondJob" cannot be added
 
 
-* Logout and login as "group1view"
+* Logout and login as "group1View"
 
 * Looking at pipeline "P6"
 * Navigate to stage "firstStage" of run "1" having counter "1"

--- a/specs/StageDetailsViewAndOperatePermissions.spec
+++ b/specs/StageDetailsViewAndOperatePermissions.spec
@@ -83,7 +83,7 @@ tags: 6786, stage-details
 * verify user can operate stage "stage2" for pipeline "p4" from stage details page
 
 
-* Logout and login as "group1view"
+* Logout and login as "group1View"
 
 * On Pipeline Dashboard Page
 * verify user cannot operate stage "defaultStage" for pipeline "p1" from stage details page

--- a/src/test/java/config/conflict-cruise-config-for-pipelineAdmin.xml
+++ b/src/test/java/config/conflict-cruise-config-for-pipelineAdmin.xml
@@ -37,7 +37,7 @@
         </role>
        <role name="misc">
         <users>
-          <user>group1view</user>
+          <user>group1View</user>
           </users>
         </role>
       </roles>

--- a/src/test/java/config/conflict-cruise-config.xml
+++ b/src/test/java/config/conflict-cruise-config.xml
@@ -36,7 +36,7 @@
         </role>
        <role name="misc">
         <users>
-          <user>group1view</user>
+          <user>group1View</user>
           </users>
         </role>
       </roles>

--- a/src/test/java/config/permissions-cruise-config.xml
+++ b/src/test/java/config/permissions-cruise-config.xml
@@ -21,7 +21,7 @@
       <roles>
         <role name="misc">
           <users>
-            <user>group1view</user>
+            <user>group1View</user>
           </users>
         </role>
       </roles>
@@ -297,7 +297,7 @@
       <view>
         <user>raghu</user>
         <user>pavan</user>
-        <user>group1view</user>
+        <user>group1View</user>
       </view>
       <operate>
         <role>misc</role>
@@ -325,7 +325,7 @@
     <pipelines group="GroupI">
     <authorization>
       <admins>
-        <user>group1view</user>
+        <user>group1View</user>
       </admins>
       <view>
         <role>misc</role>

--- a/src/test/java/config/secure-cruise-config.xml
+++ b/src/test/java/config/secure-cruise-config.xml
@@ -37,7 +37,7 @@
         </role>
        <role name="misc">
         <users>
-          <user>group1view</user>
+          <user>group1View</user>
           </users>
         </role>
       </roles>

--- a/src/test/java/config/stage-security-cruise-config.xml
+++ b/src/test/java/config/stage-security-cruise-config.xml
@@ -36,7 +36,7 @@
 				</role>
 				<role name="misc">
 					<users>
-						<user>group1view</user>
+						<user>group1View</user>
 					</users>
 				</role>
 			</roles>


### PR DESCRIPTION
Reverted these changes first since having different case in password file and in the spec actually helped us identify an inconsistence in the behavior of inbuilt password file authentication and  filebased authentication plugin with respect to user logging in with username of case different from one in password file. However on second thought decided to have specific spec for validating login with different case and not depend on the unintentional mismatch in the inputs