### PR TITLE
Fix ldap test failure

### DIFF
--- a/specs/TestUserCredentialsWithLdap.spec
+++ b/specs/TestUserCredentialsWithLdap.spec
@@ -25,7 +25,7 @@ tags: 6441, ldap, internal
 
 user should get logged in if valid ldap credentials are provided
 * Login with username "user1" and password "pass_user1"
-* User should get logged in as "user1"
+* User should get logged in as "User_user1 LastName_user1"
 
 
 user should see error message when incorrect username is provided

--- a/src/test/java/com/thoughtworks/cruise/utils/configfile/CruiseConfigDom.java
+++ b/src/test/java/com/thoughtworks/cruise/utils/configfile/CruiseConfigDom.java
@@ -1394,7 +1394,7 @@ public class CruiseConfigDom {
 	}
 
 	public Element getLdap() {
-		return (Element) root().selectSingleNode("//authConfigs/authConfig[@pluginId='"+ CruiseConstants.LDAP_AUTHENTICATION_PLUGIN_ID +"']/property[0]/value");
+		return (Element) root().selectSingleNode("//authConfigs/authConfig[@pluginId='"+ CruiseConstants.LDAP_AUTHENTICATION_PLUGIN_ID +"']/property[1]/value");
 	}
 
 	public Element getMailHost() {
@@ -1777,7 +1777,7 @@ public class CruiseConfigDom {
 
 		securityTag.add(authConfigsTag);
 		serverTag().add(securityTag);
-        
+
 	}
 
 	public void replaceServerId(String serverId) {


### PR DESCRIPTION
For LDAP authentication should default display name should be `cn` or `uid` field from ldap? need clarification before merging this PR