### PR TITLE
Removes service_mode argument when starting the server

### DIFF
--- a/src/test/java/com/thoughtworks/cruise/preconditions/ProcessIsRunning.java
+++ b/src/test/java/com/thoughtworks/cruise/preconditions/ProcessIsRunning.java
@@ -106,9 +106,7 @@ public abstract class ProcessIsRunning implements DisposableBean, InitializingBe
     protected void execute(String command, Map<String, String> envVariables) throws Exception {
         ProcessBuilder builder = new ProcessBuilder();
         builder.redirectErrorStream(true);
-        builder.environment().put("PID_FILE", pidFile());//Remove this once PR https://github.com/gocd/gocd/pull/3879 is merged
-        builder.environment().put("MANUAL_SETTING", "Y");//Remove this once PR https://github.com/gocd/gocd/pull/3879 is merged
-        
+
         /* We need to unset all environment variables that the parent agent is setting while running twist jobs. Else, all environment variables are reported as overridden. */
         builder.environment().remove("GO_SERVER_URL");
         builder.environment().remove("AGENT_DIR");
@@ -139,8 +137,8 @@ public abstract class ProcessIsRunning implements DisposableBean, InitializingBe
         	builder.environment().put("DAEMON", "N");
             builder.command("cmd ", "/c", command);
         } else {
-            builder.environment().put("DAEMON", "Y"); //Remove this once PR https://github.com/gocd/gocd/pull/3879 is merged
-            builder.command("bash", command, "service_mode");
+            builder.environment().put("DAEMON", "Y");
+            builder.command("bash", command);
         }
         System.err.println("Executing command: " + StringUtils.join(builder.command(), " ") + " (in " + getWorkingDir() + ")");
         Process process = builder.start();


### PR DESCRIPTION
Setting DAEMON env variable works because of https://github.com/gocd/gocd/pull/3879/files\#diff-f30c4d213db6e30d94eb3c78f4a515abR19