### PR TITLE
Include agentAutoRegisterKey and WebHookSecret to the test setup of c…

### DIFF
--- a/src/test/java/com/thoughtworks/cruise/context/Configuration.java
+++ b/src/test/java/com/thoughtworks/cruise/context/Configuration.java
@@ -94,11 +94,16 @@ public class Configuration {
         final String md5;
         final String serverId;
         final String tokenGenerationKey;
+        final String autoRegistrationKey;
+        final String webHookSecret;
 
-        private CurrentConfigState(String md5, String serverId, String tokenGenerationKey) {
+
+        private CurrentConfigState(String md5, String serverId, String tokenGenerationKey, String autoRegistrationKey, String webHookSecret) {
             this.md5 = md5;
             this.serverId = serverId;
             this.tokenGenerationKey = tokenGenerationKey;
+            this.autoRegistrationKey = autoRegistrationKey;
+            this.webHookSecret = webHookSecret;
         }
     }
 
@@ -106,15 +111,19 @@ public class Configuration {
         CruiseResponse configContent = getConfigContent();
         String serverId = null;
         String tokenGenerationKey = null;
+        String autoRegistrationKey = null;
+        String webHookSecret = null;
         try {
             Document dom = XmlUtil.parse(configContent.getBody());
             Node node = dom.selectSingleNode("//server/@serverId");
             serverId = node.getText();
             tokenGenerationKey = dom.selectSingleNode("//server/@tokenGenerationKey").getText();
+            autoRegistrationKey = dom.selectSingleNode("//server/@agentAutoRegisterKey").getText();
+            webHookSecret = dom.selectSingleNode("//server/@webhookSecret").getText();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        return new CurrentConfigState(configContent.getResponseHeader(X_CRUISE_CONFIG_MD5), serverId, tokenGenerationKey);
+        return new CurrentConfigState(configContent.getResponseHeader(X_CRUISE_CONFIG_MD5), serverId, tokenGenerationKey, autoRegistrationKey, webHookSecret);
     }
 
     private CruiseResponse getConfigContent() {

--- a/src/test/java/com/thoughtworks/cruise/utils/configfile/CruiseConfigDom.java
+++ b/src/test/java/com/thoughtworks/cruise/utils/configfile/CruiseConfigDom.java
@@ -1783,6 +1783,14 @@ public class CruiseConfigDom {
 		serverTag().setAttributeValue("tokenGenerationKey", tokenGenerationKey);
 	}
 
+	public void replaceAutoRegisterationKey(String autoRegisterationKey) {
+		serverTag().setAttributeValue("agentAutoRegisterKey", autoRegisterationKey);
+	}
+
+	public void replaceWebHookSecret(String webHookSecret) {
+		serverTag().setAttributeValue("webhookSecret", webHookSecret);
+	}
+
 	public String getCommandRepositoryLocation() {
 		return serverTag().attribute("commandRepositoryLocation").getText();
 	}

--- a/src/test/java/com/thoughtworks/cruise/utils/configfile/CruiseConfigFileEditor.java
+++ b/src/test/java/com/thoughtworks/cruise/utils/configfile/CruiseConfigFileEditor.java
@@ -37,6 +37,8 @@ public class CruiseConfigFileEditor extends ConfigFileContents {
     public static final String DEFAULT_CIPHER = "269298bc31c44620";
     private static final String SERVER_ID_XPATH = "//server/@serverId";
     private static final String TOKEN_GENERATION_KEY_XPATH = "//server/@tokenGenerationKey";
+    private static final String AUTO_REGISTERATION_KEY_XPATH = "//server/@agentAutoRegisterKey";
+    private static final String WEB_HOOK_SECRET_XPATH = "//server/@webhookSecret";
 
     public static File getCruiseConfigFile() {
         return new File(RuntimePath.getServerConfigPath() + "/cruise-config.xml");
@@ -52,10 +54,14 @@ public class CruiseConfigFileEditor extends ConfigFileContents {
             if (configFile.exists()) {
                 String tokenGenerationKey = XmlUtil.parse(FileUtil.readToEnd(configFile)).selectSingleNode(TOKEN_GENERATION_KEY_XPATH).getText();
                 String serverId = XmlUtil.parse(FileUtil.readToEnd(configFile)).selectSingleNode(SERVER_ID_XPATH).getText();
+                String autoRegsiterationKey = XmlUtil.parse(FileUtil.readToEnd(configFile)).selectSingleNode(AUTO_REGISTERATION_KEY_XPATH).getText();
+                String webHookSecret = XmlUtil.parse(FileUtil.readToEnd(configFile)).selectSingleNode(WEB_HOOK_SECRET_XPATH).getText();
                 Document dom = XmlUtil.parse(xml);
                 Element node = (Element) dom.selectSingleNode("//server");
                 node.setAttributeValue("serverId", serverId);
                 node.setAttributeValue("tokenGenerationKey", tokenGenerationKey);
+                node.setAttributeValue("agentAutoRegisterKey", autoRegsiterationKey);
+                node.setAttributeValue("webhookSecret", webHookSecret);
                 xml = dom.asXML();
             }
             System.err.println("Writing out config file to " + configFile.getCanonicalPath());


### PR DESCRIPTION
…onfig

Earlier it used to be not managed by test which results in server auto generating these values every time test updates the config xml, which resulted in some flaky behavior with config merge failing with merge conflicts, so handling it in the test it self