### PR TITLE
Tweak in the cleanup after completing oAuth related tests

### DIFF
--- a/specs/OAuthAccessTokenShouldBeTiedToTheUser.spec
+++ b/specs/OAuthAccessTokenShouldBeTiedToTheUser.spec
@@ -101,6 +101,8 @@ ____________________
 * Capture go state "OAuthAccessTokenShouldBeTiedToTheUser" - teardown
 * Using pipeline "pipeline1, pipeline2" - teardown
 * Login as "admin" - teardown
+* Stop server
+* Start server
 * Group admin security configuration - teardown
 
 

--- a/specs/OAuthCRUDOperations.spec
+++ b/specs/OAuthCRUDOperations.spec
@@ -63,13 +63,13 @@ This tests the CRUD operations on an OAuth client. Only an admin can perform the
 
 
 
-
-
 Teardown of contexts
 ____________________
 * Capture go state "OAuthCRUDOperations" - teardown
 * Using pipeline "basic-pipeline" - teardown
 * Login as "admin" - teardown
+* Stop server
+* Start server
 * Secure configuration - teardown
 
 

--- a/specs/OAuthScenariosWhenClientIsRemoved.spec
+++ b/specs/OAuthScenariosWhenClientIsRemoved.spec
@@ -89,6 +89,8 @@ ____________________
 * Capture go state "OAuthScenariosWhenClientIsRemoved" - teardown
 * Using pipeline "pipeline1, pipeline2" - teardown
 * Login as "admin" - teardown
+* Stop server
+* Start server
 * Group admin security configuration - teardown
 
 


### PR DESCRIPTION
Without this tweak when one spec completes and another one starts the server URL goes into infinite loop of redirection to login error page