### PR TITLE
GO_PIPELINE_COUNTER env var was removed from the server start up envi…

### DIFF
--- a/src/test/java/com/thoughtworks/cruise/preconditions/AgentLauncher.java
+++ b/src/test/java/com/thoughtworks/cruise/preconditions/AgentLauncher.java
@@ -203,8 +203,6 @@ public class AgentLauncher extends ProcessIsRunning {
         env.put("PRODUCTION_MODE", "N");
         env.put("GO_SERVER_PORT", Urls.SERVER_PORT);
         env.put("GO_SERVER_SSH_PORT", Urls.SSL_PORT);
-        String pipeline_counter = System.getenv("GO_PIPELINE_COUNTER") != null ? System.getenv("GO_PIPELINE_COUNTER") : "0";
-        env.put("GO_PIPELINE_COUNTER", pipeline_counter);
         //env.put("JVM_DEBUG", "Y"); //uncomment to debug(use deligently, as second agent will not get a bind)
         env.put("GO_AGENT_SYSTEM_PROPERTIES",
                 " -Dagent.get.work.delay=500" +

--- a/src/test/java/com/thoughtworks/cruise/preconditions/ProcessIsRunning.java
+++ b/src/test/java/com/thoughtworks/cruise/preconditions/ProcessIsRunning.java
@@ -114,7 +114,6 @@ public abstract class ProcessIsRunning implements DisposableBean, InitializingBe
         builder.environment().remove("AGENT_MAX_MEM");
         builder.environment().remove("GO_ENVIRONMENT_NAME");
         builder.environment().remove("GO_PIPELINE_NAME");
-        builder.environment().remove("GO_PIPELINE_COUNTER");
         builder.environment().remove("GO_PIPELINE_LABEL");
         builder.environment().remove("GO_STAGE_NAME");
         builder.environment().remove("GO_STAGE_COUNTER");

--- a/src/test/java/com/thoughtworks/cruise/preconditions/ServerIsRunning.java
+++ b/src/test/java/com/thoughtworks/cruise/preconditions/ServerIsRunning.java
@@ -137,8 +137,6 @@ public class ServerIsRunning extends ProcessIsRunning {
                         extraParams.toString());
         env.put("GO_SERVER_PORT", Urls.SERVER_PORT);
         env.put("GO_SERVER_SSL_PORT", Urls.SSL_PORT);
-        String pipeline_counter = System.getenv("GO_PIPELINE_COUNTER") != null ? System.getenv("GO_PIPELINE_COUNTER") : "0";
-        env.put("GO_PIPELINE_COUNTER", pipeline_counter);
         String serverMem = System.getenv("TWIST_GO_SERVER_MEM") != null ? System.getenv("TWIST_GO_SERVER_MEM") : "512m";
         String serverMaxMem = System.getenv("TWIST_GO_SERVER_MAX_MEM") != null ? System.getenv("TWIST_GO_SERVER_MAX_MEM") : "1024m";
         env.put("SERVER_MEM", serverMem);


### PR DESCRIPTION
…ronment

Include it and no need to explicitly set it to start up environment passed to the ProcessBuilder